### PR TITLE
fix: error on unequal-length sequences in calc_seq_pwm / extract_pwm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # prego 0.0.10
 
+* Fix: `calc_seq_pwm()` / `extract_pwm()` now error clearly when given sequences
+  of unequal length instead of silently recycling the shorter ones (via `rbind`)
+  and returning wrong scores. These functions build a single rectangular one-hot
+  matrix and require equal-length sequences; for variable lengths use
+  `compute_pwm()`.
 * Fix: PWM scoring no longer opens thousands of threads / fails on core-limited
   machines. `compute_pwm()`, `compute_local_pwm()` and `calc_seq_pwm()` (hence
   `extract_pwm()`) run a small per-sequence BLAS `dgemm` inside an

--- a/R/pwm.R
+++ b/R/pwm.R
@@ -48,6 +48,13 @@ calc_seq_pwm <- function(sequences, mdb, bidirect = TRUE) {
         stop("sequences must be a character vector")
     }
 
+    # calc_seq_pwm builds a single rectangular one-hot matrix, so all sequences
+    # must be the same length. Unequal lengths would silently recycle the shorter
+    # rows (via rbind) and return wrong scores - fail loudly instead.
+    if (length(unique(nchar(sequences))) > 1) {
+        cli_abort("All {.field sequences} must have the same length for {.fn extract_pwm}. For sequences of different lengths, use {.fn compute_pwm}.")
+    }
+
     # Convert sequences to uppercase and save original names
     sequences <- toupper(sequences)
     seq_names <- names(sequences)

--- a/tests/testthat/test-pwm.R
+++ b/tests/testthat/test-pwm.R
@@ -33,6 +33,22 @@ test_that("compute_pwm and calc_seq_pwm produce the same results", {
     expect_true(abs(scores_new - scores_old) < 1e-6)
 })
 
+test_that("calc_seq_pwm errors on sequences of unequal length", {
+    test_motif_db <- data.frame(
+        motif = "test_motif", pos = 1:4,
+        A = c(0.7, 0.1, 0.1, 0.1), C = c(0.1, 0.7, 0.1, 0.1),
+        G = c(0.1, 0.1, 0.7, 0.1), T = c(0.1, 0.1, 0.1, 0.7)
+    )
+    test_mdb <- create_motif_db(test_motif_db)
+    # Unequal lengths used to silently recycle (rbind) and return wrong scores.
+    expect_error(
+        calc_seq_pwm(c("ACGTACGT", "ACGTAC"), test_mdb),
+        "same length"
+    )
+    # Equal lengths still work.
+    expect_silent(calc_seq_pwm(c("ACGTACGT", "TGCATGCA"), test_mdb))
+})
+
 test_that("compute_pwm and calc_seq_pwm produce the same results with spatial", {
     res <- regress_pwm(cluster_sequences_example, cluster_mat_example[, 1],
         final_metric = "ks", spat_bin_size = 40,


### PR DESCRIPTION
## Problem

Follow-up to the `compute_pwm` variable-length fix (#38). Auditing the rest of the PWM family for the same class of bug turned up a second one in the MotifDB scoring path.

`calc_seq_pwm()` (and `extract_pwm()`, which wraps it) build a single rectangular one-hot matrix via `do.call(rbind, ...)` in `seqs_to_onehot`. With sequences of **different lengths**, `rbind` recycles the shorter rows up to the longest length, so the shorter sequences get wrong, batch-dependent scores - and it surfaces only as an easy-to-miss `rbind` warning ("number of columns of result is not a multiple of vector length"), not an error:

```r
# shorter sequence scored in a batch with a longer one vs. alone
SHORT seq in batch: -11.16   |   alone: -14.59   ->  wrong
```

## Fix

These functions are inherently equal-length (one rectangular matrix multiply against all motifs), and `compute_pwm()` already handles variable lengths correctly. So fail loudly instead of returning garbage:

```r
if (length(unique(nchar(sequences))) > 1) {
    cli_abort("All sequences must have the same length for extract_pwm(). For sequences of different lengths, use compute_pwm().")
}
```

Mirrors the existing guard in `compute_local_pwm()` (which already errors when `return_list = FALSE` and lengths differ).

## Not changed

`compute_pwm` (fixed in #38), `compute_local_pwm`, `screen_local_pwm`, `mask_sequences_by_pwm`, and `gextract.local_pwm` were all verified to be batch-independent on variable-length input. The misha package was also audited and is immune to this bug class (its scan range is always a per-PSSM constant clamped to each target's own length).

## Test

Added a test asserting `calc_seq_pwm` errors on unequal lengths and still works on equal lengths.

https://claude.ai/code/session_01PK3qefBGDoBwd9w5226FEq